### PR TITLE
Fixed path to CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
     <title>Home</title>
     <meta name="description" content="">
 
-    <link rel="stylesheet" href="http://localhost:4000/css/main.css">
-    <link rel="canonical" href="http://localhost:4000/">
+    <link rel="stylesheet" href="css/main.css">
+    <link rel="canonical" href="http://zoep.github.io/">
     <!-- <link rel="stylesheet" href="/css/more.css"> -->
     <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
 


### PR DESCRIPTION
When opening [your homepage](http://zoep.github.io/) one gets a screen filled with massive grey bars that you have to scroll past in order to get to the good stuff (see below). Looking at the source I saw that the link to the stylesheet was broken (points to `localhost`), so I fixed that.

# ~~~~~~~~~ Before ~~~~~~~~~

![screencapture-zoep-github-io-2019-01-06-18_00_18](https://user-images.githubusercontent.com/9320958/50745195-b5f9c380-11dd-11e9-9b56-559dfccb9b21.png)

# ~~~~~~~~~ After ~~~~~~~~~

![screencapture-localhost-8000-2019-01-06-18_00_40](https://user-images.githubusercontent.com/9320958/50745194-b5f9c380-11dd-11e9-84ac-00f689f97650.png)
